### PR TITLE
make jsx syntax errors tolerable

### DIFF
--- a/pkg/esbuild/esbuild.go
+++ b/pkg/esbuild/esbuild.go
@@ -2,6 +2,7 @@ package esbuild
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -30,8 +31,12 @@ func BuildFile(fs afero.Fs, filepath string) ([]byte, error) {
 
 	wrapfs := &FS{fs}
 	resolver := resolver.NewResolver(wrapfs, []string{".jsx", ".js", ".mjs"})
-	logger, _ := logging.NewStderrLog(logOptions)
+	logger, join := logging.NewStderrLog(logOptions)
 	bundle := bundler.ScanBundle(logger, wrapfs, resolver, []string{filepath}, parseOptions)
+	if join().Errors != 0 {
+		log.Println("[WARNING] ScanBundle failed")
+		return nil, nil
+	}
 	result := bundle.Compile(logger, bundleOptions)
 
 	for _, item := range result {


### PR DESCRIPTION
Right now if a jsx has some syntax issue the program terminates:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x13e1d73]

goroutine 61 [running]:
github.com/progrium/esbuild/pkg/bundler.reservedNames(0xc0001be140, 0x1, 0x1, 0xc0001c8d40, 0xc0001be140)
        /Users/lalyos/go/pkg/mod/github.com/progrium/esbuild@v0.0.0-20200327212623-fae14fb26173/pkg/bundler/renamer.go:21 +0x1a3
github.com/progrium/esbuild/pkg/bundler.renameAllSymbols(0xc0001be140, 0x1, 0x1, 0xc0001c8d40)
        /Users/lalyos/go/pkg/mod/github.com/progrium/esbuild@v0.0.0-20200327212623-fae14fb26173/pkg/bundler/renamer.go:79 +0x67
github.com/progrium/esbuild/pkg/bundler.(*Bundle).renameOrMinifyAllSymbols(0xc0001c0de0, 0xc00024a000, 0x1, 0x1, 0xc0001c8d40, 0xc00005ac64, 0x1, 0x1, 0xc0002300f0)
        /Users/lalyos/go/pkg/mod/github.com/progrium/esbuild@v0.0.0-20200327212623-fae14fb26173/pkg/bundler/bundler.go:1034 +0x3b6
github.com/progrium/esbuild/pkg/bundler.(*Bundle).compileIndependent.func1(0xc0001c0de0, 0xc00024a000, 0x1, 0x1, 0xc0002300f0, 0xc000230140, 0x1, 0x1, 0xc0001b4240, 0xc0001ba5b0, ...)
        /Users/lalyos/go/pkg/mod/github.com/progrium/esbuild@v0.0.0-20200327212623-fae14fb26173/pkg/bundler/bundler.go:1183 +0x18a
created by github.com/progrium/esbuild/pkg/bundler.(*Bundle).compileIndependent
        /Users/lalyos/go/pkg/mod/github.com/progrium/esbuild@v0.0.0-20200327212623-fae14fb26173/pkg/bundler/bundler.go:1169 +0x1c6
```

The `logging.NewStderrLog(logOptions)` second return argument is a function with a strange side effect, that if not called, compile issues (like jsx syntax error, with linecount) are completely hidden.

With this change the esbuild issue is on stderr and hotweb isnt exiting:
```
2020/04/18 17:43:31 hotweb: building kaka/lib/timer.js
kaka/lib/timer.jsx:16:1: error: Unexpected end of file
}
 ^
1 error
2020/04/18 17:43:31 [WARNING] ScanBundle failed
127.0.0.1 - - [18/Apr/2020:17:43:31 +0200] "GET /lib/timer.js?0 HTTP/1.1" 200 0
```
